### PR TITLE
Add .travis.yml suitable for Golang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+---
+language: go
+
+go:
+  - 1.6
+  - tip
+
+install: go get -v -t ./...
+
+script: go test -v ./...


### PR DESCRIPTION
to stop Travis CI from failing, because there's no `.travis.yml`, so it assumes that it's working with a Ruby program.

Travis CI builds for previous PRs that have failed with errors (e.g.: https://travis-ci.org/miolini/jsonf/builds/131450328#L6-L136), but the Travis CI build for this PR passes: https://travis-ci.org/miolini/jsonf/builds/131451987
